### PR TITLE
Fix #3: issue with Webkit jumping on position:absolute

### DIFF
--- a/js/theia-sticky-sidebar.js
+++ b/js/theia-sticky-sidebar.js
@@ -190,17 +190,17 @@
 					});
 				}
 				else if (position == 'absolute') {
+					var css = {};
+
 					if (o.stickySidebar.css('position') != 'absolute') {
-						o.stickySidebar.css({
-							'position': 'absolute',
-							'top': scrollTop + top - o.sidebar.offset().top - o.stickySidebarPaddingTop - o.stickySidebarPaddingBottom
-						});
+						css.position = 'absolute';
+						css.top = scrollTop + top - o.sidebar.offset().top - o.stickySidebarPaddingTop - o.stickySidebarPaddingBottom;
 					}
-				
-					o.stickySidebar.css({
-						'width': o.sidebar.width(),
-						'left': ''
-					});
+
+					css.width = o.sidebar.width();
+					css.left = '';
+
+					o.stickySidebar.css(css);
 				}
 				else if (position == 'static') {
 					resetSidebar();


### PR DESCRIPTION
I finally nailed down #3: the issue was happening when the sticky sidebar was set to `position:absolute`.

The problem was that the CSS was set in 2 independent `.css()`calls : one for `position` and `top`, then one for `width` and `left`, which caused Webkit to redraw in-between.

Setting all 4 properties in a single `.css()` call fixes the issue.
