### PR TITLE
Border-left isn't being accounted for for the sidebars

### DIFF
--- a/js/theia-sticky-sidebar.js
+++ b/js/theia-sticky-sidebar.js
@@ -187,7 +187,7 @@
 						'position': 'fixed',
 						'width': o.sidebar.width(),
 						'top': top,
-						'left': o.sidebar.offset().left + parseInt(o.sidebar.css('padding-left'))
+						'left': o.sidebar.offset().left + parseInt(o.sidebar.css('padding-left'))  + parseInt(o.sidebar.css('border-left'))
 					});
 				}
 				else if (position == 'absolute') {


### PR DESCRIPTION
Theia sticky bar shifts 1px to the left if the sidebar has a 1px border-left for example. This patch will take into account sidebar's border-left property - just as padding-left is accounted for.