### PR TITLE
Remove executable scripts only.

### DIFF
--- a/js/theia-sticky-sidebar.js
+++ b/js/theia-sticky-sidebar.js
@@ -105,7 +105,12 @@
                 // Get the sticky sidebar element. If none has been found, then create one.
                 o.stickySidebar = o.sidebar.find('.theiaStickySidebar');
                 if (o.stickySidebar.length == 0) {
-                    o.sidebar.find('script').remove(); // Remove <script> tags, otherwise they will be run again on the next line.
+                    // Remove <script> tags, otherwise they will be run again when added to the stickySidebar.
+                    var javaScriptMIMETypes = /(?:text|application)\/(?:x-)?(?:javascript|ecmascript)/i;
+                    o.sidebar.find('script').filter(function(index, script) {
+                        return script.type.length === 0 || script.type.match(javaScriptMIMETypes);
+                    }).remove();
+
                     o.stickySidebar = $('<div>').addClass('theiaStickySidebar').append(o.sidebar.children());
                     o.sidebar.append(o.stickySidebar);
                 }


### PR DESCRIPTION
Sometimes script tags can be used to store templates instead of executable code (See [KnockoutJS template binding](http://knockoutjs.com/documentation/template-binding.html) for an example). Removing those scripts can cause other features to break.

This PR modifies the plugin to only remove script tags with an empty type or one that matches a JavaScript MIME type.