### PR TITLE
Removed inline style for cartain cases.

### DIFF
--- a/js/theia-sticky-sidebar.js
+++ b/js/theia-sticky-sidebar.js
@@ -94,7 +94,6 @@
                 // Create sticky sidebar
                 o.sidebar.parents().css('-webkit-transform', 'none'); // Fix for WebKit bug - https://code.google.com/p/chromium/issues/detail?id=20574
                 o.sidebar.css({
-                    'position': 'relative',
                     'overflow': 'visible',
                     // The "box-sizing" must be set to "content-box" because we set a fixed height to this element when the sticky sidebar has a fixed position.
                     '-webkit-box-sizing': 'border-box',


### PR DESCRIPTION
On responsive website, sometimes, sidebar elements will be fixed content, like using off-canvas layout navigation.
This mobile style will be like this,

```
.sidebar {
  position:fixed;
}
@mdeia ~~~~~~{
  /*Mobile*/
  .sidebar {
    position:fixed;
  }
}
```

I think those inline styles for setting (like "border-box", "overflow" ) should be moved into style.css and toggle class by some trigger. Or reset proper initial styles.

I removed a style "position:relative" from javascript code anyway.
