### PR TITLE
More config params + only append style tag once

### DIFF
--- a/js/theia-sticky-sidebar.js
+++ b/js/theia-sticky-sidebar.js
@@ -77,7 +77,10 @@
             options.initialized = true;
 
             // Add CSS
-            $('head').append($('<style>.theiaStickySidebar:after {content: ""; display: table; clear: both;}</style>'));
+            var existingStylesheet = $('#theia-sticky-sidebar-stylesheet-' + options.namespace);
+            if (existingStylesheet.length === 0) {
+                $('head').append($('<style id="theia-sticky-sidebar-stylesheet-' + options.namespace + '">.theiaStickySidebar:after {content: ""; display: table; clear: both;}</style>'));
+            }
 
             $that.each(function () {
                 var o = {};

--- a/js/theia-sticky-sidebar.js
+++ b/js/theia-sticky-sidebar.js
@@ -17,7 +17,8 @@
             'updateSidebarHeight': true,
             'minWidth': 0,
             'disableOnResponsiveLayouts': true,
-            'sidebarBehavior': 'modern'
+            'sidebarBehavior': 'modern',
+            'defaultPosition': 'relative'
         };
         options = $.extend(defaults, options);
 
@@ -94,7 +95,7 @@
                 // Create sticky sidebar
                 o.sidebar.parents().css('-webkit-transform', 'none'); // Fix for WebKit bug - https://code.google.com/p/chromium/issues/detail?id=20574
                 o.sidebar.css({
-                    'position': 'relative',
+                    'position': o.options.defaultPosition,
                     'overflow': 'visible',
                     // The "box-sizing" must be set to "content-box" because we set a fixed height to this element when the sticky sidebar has a fixed position.
                     '-webkit-box-sizing': 'border-box',

--- a/js/theia-sticky-sidebar.js
+++ b/js/theia-sticky-sidebar.js
@@ -18,7 +18,8 @@
             'minWidth': 0,
             'disableOnResponsiveLayouts': true,
             'sidebarBehavior': 'modern',
-            'defaultPosition': 'relative'
+            'defaultPosition': 'relative',
+            'namespace': 'TSS'
         };
         options = $.extend(defaults, options);
 
@@ -35,7 +36,7 @@
             if (!success) {
                 console.log('TSS: Body width smaller than options.minWidth. Init is delayed.');
 
-                $(document).scroll(function (options, $that) {
+                $(document).on('scroll.' + options.namespace, function (options, $that) {
                     return function (evt) {
                         var success = tryInit(options, $that);
 
@@ -44,7 +45,7 @@
                         }
                     };
                 }(options, $that));
-                $(window).resize(function (options, $that) {
+                $(window).on('resize.' + options.namespace, function (options, $that) {
                     return function (evt) {
                         var success = tryInit(options, $that);
 
@@ -299,12 +300,12 @@
                 o.onScroll(o);
 
                 // Recalculate the sidebar's position on every scroll and resize.
-                $(document).scroll(function (o) {
+                $(document).on('scroll.' + o.options.namespace, function (o) {
                     return function () {
                         o.onScroll(o);
                     };
                 }(o));
-                $(window).resize(function (o) {
+                $(window).on('resize.' + o.options.namespace, function (o) {
                     return function () {
                         o.stickySidebar.css({'position': 'static'});
                         o.onScroll(o);
@@ -361,5 +362,7 @@
 
             return width;
         }
+
+        return this;
     }
 })(jQuery);


### PR DESCRIPTION
Hello! This PR adds three things:

1. Adds a `defaultPosition` option (useful if the bound element uses something other than `position: relative` by default).
2. Adds a `namespace` option, to make it possible to unbind elements (this is useful if we want to re-render bound elements). This fixes issue https://github.com/WeCodePixels/theia-sticky-sidebar/issues/31.
3. Only append the style tag to the HEAD if it doesn't already exist. Otherwise we end up with a duplicate style tag for every time this library is initialized.

Let me know if you need anything further to get this merged.

Cheers!
Andrew